### PR TITLE
DEVOPS-8792 - Added I3 class machines to template

### DIFF
--- a/quickstart-for-custom/alfresco-one-master.template
+++ b/quickstart-for-custom/alfresco-one-master.template
@@ -202,7 +202,13 @@
               "t2.large",
               "m4.large",
               "m4.xlarge",
-              "m4.2xlarge"
+              "m4.2xlarge",
+              "i3.large",
+              "i3.xlarge",
+              "i3.2xlarge",
+              "i3.4xlarge",
+              "i3.8xlarge",
+              "i3.16xlarge"
             ],
             "ConstraintDescription": "Must contain valid instance type",
             "Default": "m4.xlarge",
@@ -499,7 +505,7 @@
             "Description": "The CIDR IP range that is permitted to access the Alfresco One software. We recommend that you set this value to a trusted IP range.",
             "Type": "String"
         },
-         "BastionAMIOS": {
+        "BastionAMIOS": {
             "AllowedValues": [
                 "Amazon-Linux-HVM",
                 "CentOS-7-HVM",

--- a/quickstart-for-custom/alfresco-one.template
+++ b/quickstart-for-custom/alfresco-one.template
@@ -179,7 +179,13 @@
               "t2.large",
               "m4.large",
               "m4.xlarge",
-              "m4.2xlarge"
+              "m4.2xlarge",
+              "i3.large",
+              "i3.xlarge",
+              "i3.2xlarge",
+              "i3.4xlarge",
+              "i3.8xlarge",
+              "i3.16xlarge"
             ],
             "ConstraintDescription": "Must contain valid instance type",
             "Default": "m4.xlarge",
@@ -921,7 +927,7 @@
             "FileSystemTags" : [
               {
                 "Key" : "Name",
-                "Value" : { "Ref": "AlfrescoContentStoreFileSystemName" },
+                "Value" : { "Ref": "AlfrescoContentStoreFileSystemName" }
               }
             ]
           }


### PR DESCRIPTION
Additions:

- Added I3 class machines to the templates
- Minor template fixes

Issues noted:

- In `alfresco-one.template` there are duplicate keys. Namely `ElasticSearchMonInstance`. This isnt allowed in Cloudformation as this means that you are naming two separate resources with the same name. How are you meant to refer to them? Im not even sure if two are needed.
- The error you are getting is with the `my_customization.sh` script. I would suggest sshing onto one of the Alfresco instances and running it to see what happens. I dont have access to do so.